### PR TITLE
Add support of Popup LOV - APEX Item.

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -80,7 +80,12 @@ var apexutils = this.apexutils || {};
                     itemCount = pData.items.length;
                     itemArray = pData.items;
                     for( var i = 0; i < itemCount; i++ ) {
-                        $s( itemArray[i].id, itemArray[i].value, null, options.suppressChangeEvent);
+                        if(itemArray[i].display) {
+                          $s( itemArray[i].id, itemArray[i].value, itemArray[i].display, options.suppressChangeEvent);
+                        } else {
+                          $s( itemArray[i].id, itemArray[i].value, null, options.suppressChangeEvent); 
+                        } 
+                          
                     }
                 }
 


### PR DESCRIPTION
"Popup LOV" is now a standard input type in APEX, to replace an old Select List. But using of this item has some difficulties, which can be fixed using "Execute-PL-SQL-Code" plugin. 
  
By default developer should set display value of Popup LOV-Item manually, when the value is returned using Execute Pl/SQL Dynamic Action or Excute PL-SQL plugin.
Workaround is mentioned on https://community.oracle.com/thread/4274006
Improvements made in this commit allows to fill display value completely automatically, without any care. Plugin detects all Popup LOV's mentioned in return items, automatically get display values and set it to the items on the page.

! To facilitate a code review, plugin itself was not changed, only source files was improved.